### PR TITLE
Modify quantity wrapper when quick add not present

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2,3 +2,7 @@
 .prod__option-label__quantity {
   display: block;
 }
+
+.form__input-wrapper--select.flex-1 {
+  margin-bottom: 0 !important;
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -5,3 +5,7 @@
 .prod__option-label__quantity {
   display: block;
 }
+
+.form__input-wrapper--select.flex-1 {
+  margin-bottom: 0 !important;
+}

--- a/snippets/main-product-blocks.liquid
+++ b/snippets/main-product-blocks.liquid
@@ -321,9 +321,9 @@
           {{ 'products.product.quantity' | t }}
         </label>
       {% endif %}
-      <div class="flex flex-wrap items-end">
+      <div class="flex flex-wrap items-end{% unless block.settings.show_double_qty_btn %} gap-2{% endunless %}">
         {% if block.settings.show_quantity_selector %}
-          <div class="form__input-wrapper form__input-wrapper--select mr-5 w-32" data-quantity-input-wrapper>
+          <div class="form__input-wrapper form__input-wrapper--select{% if block.settings.show_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
             {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: block.settings.show_double_qty_btn %}
           </div>
                       {% endif %}
@@ -333,8 +333,12 @@
                           if show_dynamic_checkout
                           assign btn_class = 'sf__btn-secondary'
                           endif
+                          assign atc_class = btn_class
+                          unless block.settings.show_double_qty_btn
+                            assign atc_class = atc_class | append: ' flex-1'
+                          endunless
                         %}
-                        {% render 'product-atc', class: btn_class, product: product %}
+                        {% render 'product-atc', class: atc_class, product: product %}
                         {% if section.settings.show_atwl and section.settings.layout == 'layout-7' %}
                           <div class="ml-2 hidden md:block">{% render 'tooltip', type: 'wishlist', class_name: 'sf__tooltip-top' %}</div>
                         {% endif %}

--- a/snippets/product-form.liquid
+++ b/snippets/product-form.liquid
@@ -67,9 +67,9 @@
             </label>
           {% endif %}
 
-          <div class="flex flex-wrap items-end">
+          <div class="flex flex-wrap items-end{% unless show_double_qty_btn %} gap-2{% endunless %}">
             {% if show_quantity_selector == true %}
-              <div class="form__input-wrapper form__input-wrapper--select mr-5 w-32" data-quantity-input-wrapper>
+              <div class="form__input-wrapper form__input-wrapper--select{% if show_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
                 {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: show_double_qty_btn %}
               </div>
             {% endif %}
@@ -79,8 +79,12 @@
                 if enable_dynamic_checkout
                   assign btn_class = 'sf__btn-secondary'
                 endif
+                assign atc_class = btn_class
+                unless show_double_qty_btn
+                  assign atc_class = atc_class | append: ' flex-1'
+                endunless
               %}
-              {% render 'product-atc', class: btn_class, product: product %}
+              {% render 'product-atc', class: atc_class, product: product %}
               {% if section.settings.show_atwl and section.settings.layout == 'layout-7' %}
                 <div class="ml-2 hidden md:block">
                   {% render 'tooltip', type: 'wishlist', class_name: 'sf__tooltip-top' %}


### PR DESCRIPTION
## Summary
- make quantity/add-to-cart section flexible when `.double-qty-btn` is missing
- apply gap between elements only in that case
- remove bottom margin on quantity wrapper when it uses `flex-1` layout

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68895deed534832d96c525084d96a7a9