### PR TITLE
Modify quantity wrapper when quick add not present

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2,3 +2,7 @@
 .prod__option-label__quantity {
   display: block;
 }
+
+.form__input-wrapper--select.flex-1 {
+  margin-bottom: 0 !important;
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -5,3 +5,7 @@
 .prod__option-label__quantity {
   display: block;
 }
+
+.form__input-wrapper--select.flex-1 {
+  margin-bottom: 0 !important;
+}

--- a/snippets/main-product-blocks.liquid
+++ b/snippets/main-product-blocks.liquid
@@ -301,6 +301,14 @@
                 unless section.settings.show_featured_media
                   assign selected_variant_id = product.selected_variant.id
                 endunless
+
+                assign min_qty = product.metafields.custom.minimum_quantity | default: 1 | plus: 0
+                assign has_double_qty_btn = false
+                if block.settings.show_double_qty_btn
+                  if min_qty > 1 or request.design_mode
+                    assign has_double_qty_btn = true
+                  endif
+                endif
               %}
 <product-form class="f-product-form" data-product-id="{{ product.id }}">
   {%- form 'product', product,
@@ -321,9 +329,9 @@
           {{ 'products.product.quantity' | t }}
         </label>
       {% endif %}
-      <div class="flex flex-wrap items-end">
+      <div class="flex flex-wrap items-end{% unless has_double_qty_btn %} gap-2{% endunless %}">
         {% if block.settings.show_quantity_selector %}
-          <div class="form__input-wrapper form__input-wrapper--select mr-5 w-32" data-quantity-input-wrapper>
+          <div class="form__input-wrapper form__input-wrapper--select{% if has_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
             {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: block.settings.show_double_qty_btn %}
           </div>
                       {% endif %}
@@ -333,8 +341,12 @@
                           if show_dynamic_checkout
                           assign btn_class = 'sf__btn-secondary'
                           endif
+                          assign atc_class = btn_class
+                          unless has_double_qty_btn
+                            assign atc_class = atc_class | append: ' flex-1'
+                          endunless
                         %}
-                        {% render 'product-atc', class: btn_class, product: product %}
+                        {% render 'product-atc', class: atc_class, product: product %}
                         {% if section.settings.show_atwl and section.settings.layout == 'layout-7' %}
                           <div class="ml-2 hidden md:block">{% render 'tooltip', type: 'wishlist', class_name: 'sf__tooltip-top' %}</div>
                         {% endif %}

--- a/snippets/product-form.liquid
+++ b/snippets/product-form.liquid
@@ -29,6 +29,13 @@
   if show_double_qty_btn == nil
     assign show_double_qty_btn = section.settings.show_double_qty_btn | default: false
   endif
+  assign min_qty = product.metafields.custom.minimum_quantity | default: 1 | plus: 0
+  assign has_double_qty_btn = false
+  if show_double_qty_btn
+    if min_qty > 1 or request.design_mode
+      assign has_double_qty_btn = true
+    endif
+  endif
 -%}
 
 <div class="form__error-message-wrapper hidden" data-error-message-wrapper role="alert">
@@ -67,9 +74,9 @@
             </label>
           {% endif %}
 
-          <div class="flex flex-wrap items-end">
+          <div class="flex flex-wrap items-end{% unless has_double_qty_btn %} gap-2{% endunless %}">
             {% if show_quantity_selector == true %}
-              <div class="form__input-wrapper form__input-wrapper--select mr-5 w-32" data-quantity-input-wrapper>
+              <div class="form__input-wrapper form__input-wrapper--select{% if has_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
                 {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: show_double_qty_btn %}
               </div>
             {% endif %}
@@ -79,8 +86,12 @@
                 if enable_dynamic_checkout
                   assign btn_class = 'sf__btn-secondary'
                 endif
+                assign atc_class = btn_class
+                unless has_double_qty_btn
+                  assign atc_class = atc_class | append: ' flex-1'
+                endunless
               %}
-              {% render 'product-atc', class: btn_class, product: product %}
+              {% render 'product-atc', class: atc_class, product: product %}
               {% if section.settings.show_atwl and section.settings.layout == 'layout-7' %}
                 <div class="ml-2 hidden md:block">
                   {% render 'tooltip', type: 'wishlist', class_name: 'sf__tooltip-top' %}

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -106,7 +106,7 @@
       "settings": {
         "container": "container",
         "grid_layout": "grid",
-        "grid_columns": "5",
+        "grid_columns": "2",
         "show_columns_switcher": false,
         "pagination_limit": 50,
         "paginate_type": "infinite",

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -1,1 +1,143 @@
-{"sections":{"collection-header":{"type":"collection-page-header","blocks":{"0e2f4cdc-52ea-4a81-8981-2c1da0f34854":{"type":"banner","disabled":true,"settings":{"collection":""}}},"block_order":["0e2f4cdc-52ea-4a81-8981-2c1da0f34854"],"settings":{"container":"container-fluid","layout":"inside","header_height":"small","text_alignment":"center","vertical_alignment":"center","text_color":"dark","bg_color":"#ffffff","enable_parallax":false,"upper_title":false,"show_desc":false,"collection_all_desc":""}},"main":{"type":"main-collection-product-grid","blocks":{"26ef6509-772d-4c44-bd90-efc089bd9355":{"type":"filter","settings":{"design_filtergroup":"inrow","title":"Dimensiuni","filtergroup":"100cm,120cm,140cm","show_label":true,"use_accordion":true,"open_filtergroup":true}},"e12de6da-eab8-4abe-967c-06d0d959a18a":{"type":"filter","settings":{"design_filtergroup":"color","title":"Culoare","filtergroup":"Blue, Red, White ,Black ,Pink ,Silver,Purple,Brown,Yellow,Grey,Green,Tan,Violet,Dark Grey,Beige,Light Blue, Dark Blue, Light Grey, Light Pink, Mint, Rose Gold, Night Blue, Copper, Coral, Rosy Brown, Alb, Negru, Albastru","show_label":true,"use_accordion":true,"open_filtergroup":true}},"fa31a837-9c99-4c92-8cfe-0527ffbe7b15":{"type":"filter","settings":{"design_filtergroup":"button","title":"Pret","filtergroup":"0 - 100 lei,100 - 200 lei,200 - 300 lei,300 - 400 lei,400 - 500 lei,500 - 1000 lei, 1000+ lei","show_label":false,"use_accordion":true,"open_filtergroup":true}},"4903963a-90f0-4fe1-be23-ee4f8749e483":{"type":"filter","settings":{"design_filtergroup":"inrow","title":"Brand","filtergroup":"ConceptSGM,Retrolie,Abby,Brook,Learts,Vagabond","show_label":false,"use_accordion":false,"open_filtergroup":true}},"00b3badd-1613-4230-85d8-f87f04306aaa":{"type":"filter","settings":{"design_filtergroup":"inrow","title":"Tag","filtergroup":"Dress,Tops,Shirts,Fashion,Hats,Sandal,Belt,Bags,Snacker,Denim,ConceptSGM,Vagabond,Sunglasses, Beachwear,Vintage","show_label":false,"use_accordion":true,"open_filtergroup":true}}},"block_order":["26ef6509-772d-4c44-bd90-efc089bd9355","e12de6da-eab8-4abe-967c-06d0d959a18a","fa31a837-9c99-4c92-8cfe-0527ffbe7b15","4903963a-90f0-4fe1-be23-ee4f8749e483","00b3badd-1613-4230-85d8-f87f04306aaa"],"settings":{"container":"container-fluid","grid_layout":"grid","grid_columns":"5","show_columns_switcher":false,"pagination_limit":35,"paginate_type":"infinite","show_sorting":true,"show_filter":false,"filters_type":"tags_filter","sidebar":"fixed","sidebar_title":"Filtre","limit_height_widget":false,"limit_height":300,"change_product_variant_on_fitlering":true,"show_product_count":true,"collapsed_groups":"Brand, Vendor, Size, dimensiuni","color_swatches":"color,colour,couleur,farbe,culoare"}},"recent-viewed":{"type":"recent-viewed-products","settings":{"container":"container","heading":"Vizualizate Recent","limit":8,"columns":4,"column_gap":30,"enable_slider":true}}},"order":["collection-header","main","recent-viewed"]}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "sections": {
+    "collection-header": {
+      "type": "collection-page-header",
+      "blocks": {
+        "0e2f4cdc-52ea-4a81-8981-2c1da0f34854": {
+          "type": "banner",
+          "disabled": true,
+          "settings": {
+            "collection": ""
+          }
+        }
+      },
+      "block_order": [
+        "0e2f4cdc-52ea-4a81-8981-2c1da0f34854"
+      ],
+      "settings": {
+        "container": "container-fluid",
+        "layout": "inside",
+        "header_height": "small",
+        "text_alignment": "center",
+        "vertical_alignment": "center",
+        "text_color": "dark",
+        "bg_color": "#ffffff",
+        "enable_parallax": false,
+        "upper_title": false,
+        "show_desc": false,
+        "collection_all_desc": ""
+      }
+    },
+    "main": {
+      "type": "main-collection-product-grid",
+      "blocks": {
+        "26ef6509-772d-4c44-bd90-efc089bd9355": {
+          "type": "filter",
+          "settings": {
+            "design_filtergroup": "inrow",
+            "title": "Dimensiuni",
+            "filtergroup": "100cm,120cm,140cm",
+            "show_label": true,
+            "use_accordion": true,
+            "open_filtergroup": true
+          }
+        },
+        "e12de6da-eab8-4abe-967c-06d0d959a18a": {
+          "type": "filter",
+          "settings": {
+            "design_filtergroup": "color",
+            "title": "Culoare",
+            "filtergroup": "Blue, Red, White ,Black ,Pink ,Silver,Purple,Brown,Yellow,Grey,Green,Tan,Violet,Dark Grey,Beige,Light Blue, Dark Blue, Light Grey, Light Pink, Mint, Rose Gold, Night Blue, Copper, Coral, Rosy Brown, Alb, Negru, Albastru",
+            "show_label": true,
+            "use_accordion": true,
+            "open_filtergroup": true
+          }
+        },
+        "fa31a837-9c99-4c92-8cfe-0527ffbe7b15": {
+          "type": "filter",
+          "settings": {
+            "design_filtergroup": "button",
+            "title": "Pret",
+            "filtergroup": "0 - 100 lei,100 - 200 lei,200 - 300 lei,300 - 400 lei,400 - 500 lei,500 - 1000 lei, 1000+ lei",
+            "show_label": false,
+            "use_accordion": true,
+            "open_filtergroup": true
+          }
+        },
+        "4903963a-90f0-4fe1-be23-ee4f8749e483": {
+          "type": "filter",
+          "settings": {
+            "design_filtergroup": "inrow",
+            "title": "Brand",
+            "filtergroup": "ConceptSGM,Retrolie,Abby,Brook,Learts,Vagabond",
+            "show_label": false,
+            "use_accordion": false,
+            "open_filtergroup": true
+          }
+        },
+        "00b3badd-1613-4230-85d8-f87f04306aaa": {
+          "type": "filter",
+          "settings": {
+            "design_filtergroup": "inrow",
+            "title": "Tag",
+            "filtergroup": "Dress,Tops,Shirts,Fashion,Hats,Sandal,Belt,Bags,Snacker,Denim,ConceptSGM,Vagabond,Sunglasses, Beachwear,Vintage",
+            "show_label": false,
+            "use_accordion": true,
+            "open_filtergroup": true
+          }
+        }
+      },
+      "block_order": [
+        "26ef6509-772d-4c44-bd90-efc089bd9355",
+        "e12de6da-eab8-4abe-967c-06d0d959a18a",
+        "fa31a837-9c99-4c92-8cfe-0527ffbe7b15",
+        "4903963a-90f0-4fe1-be23-ee4f8749e483",
+        "00b3badd-1613-4230-85d8-f87f04306aaa"
+      ],
+      "settings": {
+        "container": "container",
+        "grid_layout": "grid",
+        "grid_columns": "5",
+        "show_columns_switcher": false,
+        "pagination_limit": 50,
+        "paginate_type": "infinite",
+        "show_sorting": true,
+        "show_filter": false,
+        "filters_type": "tags_filter",
+        "sidebar": "fixed",
+        "sidebar_title": "Filtre",
+        "limit_height_widget": false,
+        "limit_height": 300,
+        "change_product_variant_on_fitlering": true,
+        "show_product_count": true,
+        "collapsed_groups": "Brand, Vendor, Size, dimensiuni",
+        "color_swatches": "color,colour,couleur,farbe,culoare"
+      }
+    },
+    "recent-viewed": {
+      "type": "recent-viewed-products",
+      "settings": {
+        "container": "container",
+        "heading": "Vizualizate Recent",
+        "limit": 8,
+        "columns": 4,
+        "column_gap": 30,
+        "enable_slider": true
+      }
+    }
+  },
+  "order": [
+    "collection-header",
+    "main",
+    "recent-viewed"
+  ]
+}

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -106,7 +106,7 @@
       "settings": {
         "container": "container",
         "grid_layout": "grid",
-        "grid_columns": "2",
+        "grid_columns": "5",
         "show_columns_switcher": false,
         "pagination_limit": 50,
         "paginate_type": "infinite",

--- a/templates/product.json
+++ b/templates/product.json
@@ -45,7 +45,7 @@
           "type": "buy_buttons",
           "settings": {
             "show_quantity_selector": true,
-            "show_double_qty_btn": false,
+            "show_double_qty_btn": true,
             "show_atc_button": true,
             "show_dynamic_checkout": false
           }

--- a/templates/product.json
+++ b/templates/product.json
@@ -1,1 +1,201 @@
-{"sections":{"breadcrumb":{"type":"breadcrumb","settings":{"container":"container","text_alignment":"center","hide_current":false,"hide_on_mb":false}},"main":{"type":"main-product","blocks":{"title":{"type":"title","settings":{}},"price":{"type":"price","settings":{"show_saving":false}},"variant_picker":{"type":"variant_picker","settings":{"size_title":"Size"}},"b9afb0fa-f039-4f85-b9f1-3fa185f14340":{"type":"short_description","settings":{}},"buy_buttons":{"type":"buy_buttons","settings":{"show_quantity_selector":true,"show_double_qty_btn":true,"show_atc_button":true,"show_dynamic_checkout":false}},"5cb26444-7bc7-411a-957f-8aad695f0f9f":{"type":"shipping","settings":{"show_delivery_times":true,"deliver_text":"Livrare Estimata:","deliver_days":"7","date_format":"%b %d","show_shipping_text":true,"shipping_text":"<p><strong>Livrare Gratuita: <\/strong>Orice comanda peste 200 lei<\/p>"}},"853d9a4e-7f41-4c6a-bc84-42d9218f2abe":{"type":"visitors","settings":{"live_views_text":"{count_number} persoane vizualizeaza acest produs acum","live_views_range":"20-30","live_view_duration":"10","live_view_icon_blinks":true}},"addons":{"type":"addons","settings":{"show_atcp":true,"show_ask_a_question":true,"show_social":true}},"2964af7f-257c-4f6f-a6ac-6f5265f14553":{"type":"custom_text","disabled":true,"settings":{"content":""}},"63a6f2a1-453e-4b58-82c4-78dd1f750a42":{"type":"custom_liquid","settings":{"custom_liquid":""}},"a4cbf602-872a-4e6d-8ca5-4b28b3542e27":{"type":"trust_badge","disabled":true,"settings":{"trust_badges_text":"<p>Guarantee safe & secure checkout<\/p>","trust_badges_image_width":"100%","position":"below"}}},"block_order":["title","price","variant_picker","b9afb0fa-f039-4f85-b9f1-3fa185f14340","buy_buttons","5cb26444-7bc7-411a-957f-8aad695f0f9f","853d9a4e-7f41-4c6a-bc84-42d9218f2abe","addons","2964af7f-257c-4f6f-a6ac-6f5265f14553","63a6f2a1-453e-4b58-82c4-78dd1f750a42","a4cbf602-872a-4e6d-8ca5-4b28b3542e27"],"settings":{"container":"container","layout":"layout-6","show_atwl":true,"enable_history_state":true,"enable_variant_group_images":true,"show_featured_media":true,"show_zoom_button":true,"enable_video_autoplay":false,"show_nav_media_mobile":false,"show_pagination_mobile":true,"use_sticky_atc":true,"use_sticky_atc_on_mobile":true,"enable_dynamic_checkout":false,"sticky_atc_wishtlist":false,"sticky_atc_compare":false}},"product-details-tabs":{"type":"product-details-tabs","blocks":{"description":{"type":"description","settings":{"header":"Descriere"}},"tab":{"type":"tab","settings":{"header":"Livrare & Rettur","content":"<p>Informatii despre retur si livrare aici<\/p>","content_page":"livrare-retur"}}},"block_order":["description","tab"],"settings":{"container":"container","bg_color":"","default_open":true}},"sma_reviews_section_auto":{"type":"reviews-importer-product","settings":{"lai_product":""}},"product-recommendations":{"type":"product-recommendations","settings":{"container":"container","heading":"S-ar putea sa iti placa si","text_align":"left","limit":8,"columns":4,"column_gap":30,"enable_slider":true}},"recent-viewed-products":{"type":"recent-viewed-products","settings":{"container":"container","heading":"Recent Vizualizate","limit":8,"columns":4,"column_gap":30,"enable_slider":true}}},"order":["breadcrumb","main","product-details-tabs","sma_reviews_section_auto","product-recommendations","recent-viewed-products"]}
+/*
+ * ------------------------------------------------------------
+ * IMPORTANT: The contents of this file are auto-generated.
+ *
+ * This file may be updated by the Shopify admin theme editor
+ * or related systems. Please exercise caution as any changes
+ * made to this file may be overwritten.
+ * ------------------------------------------------------------
+ */
+{
+  "sections": {
+    "breadcrumb": {
+      "type": "breadcrumb",
+      "settings": {
+        "container": "container",
+        "text_alignment": "center",
+        "hide_current": false,
+        "hide_on_mb": false
+      }
+    },
+    "main": {
+      "type": "main-product",
+      "blocks": {
+        "title": {
+          "type": "title",
+          "settings": {}
+        },
+        "price": {
+          "type": "price",
+          "settings": {
+            "show_saving": false
+          }
+        },
+        "variant_picker": {
+          "type": "variant_picker",
+          "settings": {
+            "size_title": "Size"
+          }
+        },
+        "b9afb0fa-f039-4f85-b9f1-3fa185f14340": {
+          "type": "short_description",
+          "settings": {}
+        },
+        "buy_buttons": {
+          "type": "buy_buttons",
+          "settings": {
+            "show_quantity_selector": true,
+            "show_double_qty_btn": false,
+            "show_atc_button": true,
+            "show_dynamic_checkout": false
+          }
+        },
+        "5cb26444-7bc7-411a-957f-8aad695f0f9f": {
+          "type": "shipping",
+          "settings": {
+            "show_delivery_times": true,
+            "deliver_text": "Livrare Estimata:",
+            "deliver_days": "7",
+            "date_format": "%b %d",
+            "show_shipping_text": true,
+            "shipping_text": "<p><strong>Livrare Gratuita: </strong>Orice comanda peste 200 lei</p>"
+          }
+        },
+        "853d9a4e-7f41-4c6a-bc84-42d9218f2abe": {
+          "type": "visitors",
+          "settings": {
+            "live_views_text": "{count_number} persoane vizualizeaza acest produs acum",
+            "live_views_range": "20-30",
+            "live_view_duration": "10",
+            "live_view_icon_blinks": true
+          }
+        },
+        "addons": {
+          "type": "addons",
+          "settings": {
+            "show_atcp": true,
+            "show_ask_a_question": true,
+            "show_social": true
+          }
+        },
+        "2964af7f-257c-4f6f-a6ac-6f5265f14553": {
+          "type": "custom_text",
+          "disabled": true,
+          "settings": {
+            "content": ""
+          }
+        },
+        "63a6f2a1-453e-4b58-82c4-78dd1f750a42": {
+          "type": "custom_liquid",
+          "settings": {
+            "custom_liquid": ""
+          }
+        },
+        "a4cbf602-872a-4e6d-8ca5-4b28b3542e27": {
+          "type": "trust_badge",
+          "disabled": true,
+          "settings": {
+            "trust_badges_text": "<p>Guarantee safe & secure checkout</p>",
+            "trust_badges_image_width": "100%",
+            "position": "below"
+          }
+        }
+      },
+      "block_order": [
+        "title",
+        "price",
+        "variant_picker",
+        "b9afb0fa-f039-4f85-b9f1-3fa185f14340",
+        "buy_buttons",
+        "5cb26444-7bc7-411a-957f-8aad695f0f9f",
+        "853d9a4e-7f41-4c6a-bc84-42d9218f2abe",
+        "addons",
+        "2964af7f-257c-4f6f-a6ac-6f5265f14553",
+        "63a6f2a1-453e-4b58-82c4-78dd1f750a42",
+        "a4cbf602-872a-4e6d-8ca5-4b28b3542e27"
+      ],
+      "settings": {
+        "container": "container",
+        "layout": "layout-6",
+        "show_atwl": true,
+        "enable_history_state": true,
+        "enable_variant_group_images": true,
+        "show_featured_media": true,
+        "show_zoom_button": true,
+        "enable_video_autoplay": false,
+        "show_nav_media_mobile": false,
+        "show_pagination_mobile": true,
+        "use_sticky_atc": true,
+        "use_sticky_atc_on_mobile": true,
+        "enable_dynamic_checkout": false,
+        "sticky_atc_wishtlist": false,
+        "sticky_atc_compare": false
+      }
+    },
+    "product-details-tabs": {
+      "type": "product-details-tabs",
+      "blocks": {
+        "description": {
+          "type": "description",
+          "settings": {
+            "header": "Descriere"
+          }
+        },
+        "tab": {
+          "type": "tab",
+          "settings": {
+            "header": "Livrare & Rettur",
+            "content": "<p>Informatii despre retur si livrare aici</p>",
+            "content_page": "livrare-retur"
+          }
+        }
+      },
+      "block_order": [
+        "description",
+        "tab"
+      ],
+      "settings": {
+        "container": "container",
+        "bg_color": "",
+        "default_open": true
+      }
+    },
+    "sma_reviews_section_auto": {
+      "type": "reviews-importer-product",
+      "settings": {
+        "lai_product": ""
+      }
+    },
+    "product-recommendations": {
+      "type": "product-recommendations",
+      "settings": {
+        "container": "container",
+        "heading": "S-ar putea sa iti placa si",
+        "text_align": "left",
+        "limit": 8,
+        "columns": 4,
+        "column_gap": 30,
+        "enable_slider": true
+      }
+    },
+    "recent-viewed-products": {
+      "type": "recent-viewed-products",
+      "settings": {
+        "container": "container",
+        "heading": "Recent Vizualizate",
+        "limit": 8,
+        "columns": 4,
+        "column_gap": 30,
+        "enable_slider": true
+      }
+    }
+  },
+  "order": [
+    "breadcrumb",
+    "main",
+    "product-details-tabs",
+    "sma_reviews_section_auto",
+    "product-recommendations",
+    "recent-viewed-products"
+  ]
+}


### PR DESCRIPTION
## Summary
- make quantity/add-to-cart section flexible when `.double-qty-btn` is missing and when product minimum quantity is 1 or undefined
- apply gap between elements only in that case
- remove bottom margin on quantity wrapper when it uses `flex-1` layout

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68895deed534832d96c525084d96a7a9