### PR TITLE
Allow manual quantity input without step snapping

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7455,14 +7455,10 @@ addEventDelegate({
     const step = Number(input.getAttribute('data-min-qty')) || Number(input.step) || 1;
     const min = Number(input.min) || step;
     const max = Number(input.max) || Infinity;
-    let quantity = Number(input.value) || min;
-
-    // Snap manual input to the closest allowed value
+    let quantity = parseFloat(input.value);
+    if (Number.isNaN(quantity)) quantity = min;
+    if (quantity < min) quantity = min;
     if (quantity > max) quantity = max;
-    if (quantity !== max) {
-      quantity = Math.floor((quantity - min) / step) * step + min;
-      if (quantity < min) quantity = min;
-    }
 
     input.value = quantity;
     if (quantity >= max) {
@@ -8862,17 +8858,10 @@ _defineProperty(this, "handleQtyInputChange", e => {
   const attrMax = parseFloat(input.max);
   if (!Number.isNaN(attrMax)) max = attrMax;
 
-  let val = Number(input.value) || min;
-
-  const snapDown = v => {
-    if (!isFinite(v)) return min;
-    if (v < min) return min;
-    return Math.floor((v - min) / step) * step + min;
-  };
-
-  if (val > max) val = max;
-  if (val !== max) val = snapDown(val);
+  let val = parseFloat(input.value);
+  if (Number.isNaN(val)) val = min;
   if (val < min) val = min;
+  if (val > max) val = max;
   input.value = val;
 
   // Colorare roșie la maxim

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -19,13 +19,19 @@
     return val;
   }
 
-  function validateAndHighlightQty(input){
+  function validateAndHighlightQty(input, snap){
+    if(snap === undefined) snap = true;
     var step = parseInt(input.getAttribute('data-min-qty'), 10) || parseInt(input.step,10) || 1;
     var min = parseInt(input.min, 10) || step;
     var max = input.max ? parseInt(input.max, 10) : Infinity;
     var val = parseInt(input.value, 10);
     val = isNaN(val) ? min : val;
-    val = clampAndSnap(val, step, min, max);
+    if(snap){
+      val = clampAndSnap(val, step, min, max);
+    }else{
+      if(val < min) val = min;
+      if(val > max) val = max;
+    }
     input.value = val;
     if(val >= max){
       input.classList.add('text-red-600');
@@ -79,7 +85,7 @@ var LABEL_SUFFIX = '';
       if(input === changedInput) return;
       if(input.value !== value){
         input.value = value;
-        validateAndHighlightQty(input);
+        validateAndHighlightQty(input, false);
         updateIncreaseBtnState(input);
         input.dispatchEvent(new Event('input', { bubbles: true }));
         input.dispatchEvent(new Event('change', { bubbles: true }));
@@ -94,19 +100,19 @@ var LABEL_SUFFIX = '';
       input.dataset.qtyListener = '1';
       ['input','change','blur'].forEach(function(ev){
         input.addEventListener(ev, function(){
-          validateAndHighlightQty(input);
+          validateAndHighlightQty(input, false);
           updateIncreaseBtnState(input);
           syncOtherQtyInputs(input);
         });
       });
       input.addEventListener('keypress', function(e){
         if(e.key === 'Enter'){
-          validateAndHighlightQty(input);
+          validateAndHighlightQty(input, false);
           updateIncreaseBtnState(input);
           syncOtherQtyInputs(input);
         }
       });
-      validateAndHighlightQty(input);
+      validateAndHighlightQty(input, true);
       updateIncreaseBtnState(input);
       syncOtherQtyInputs(input);
     });


### PR DESCRIPTION
## Summary
- relax manual quantity validation for product and cart inputs
- keep step-based snapping when quantity buttons are used

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68897c2f88a0832d899d1fdcdebd12ec