### PR TITLE
Fix quantity input clamp logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Documentatie utilizare inputuri de cantitate
+
+Acest proiect foloseste `double-qty.js` pentru functionalitatile suplimentare ale campurilor de cantitate.
+
+## Initializare
+
+Scriptul ataseaza automat evenimentele necesare la incarcarea paginii (`DOMContentLoaded`) si la evenimentele Shopify `shopify:section:load`, `shopify:cart:updated` si `shopify:product:updated`.
+
+Daca elemente cu inputuri de cantitate sunt adaugate dinamic (ex. modul quick view, sticky ATC sau prin incarcari AJAX), apelati:
+
+```javascript
+window.doubleQtyInit();
+```
+
+Functia va reinitializeaza butoanele si inputurile pentru zonele nou adaugate.

--- a/assets/app.js
+++ b/assets/app.js
@@ -7455,14 +7455,10 @@ addEventDelegate({
     const step = Number(input.getAttribute('data-min-qty')) || Number(input.step) || 1;
     const min = Number(input.min) || step;
     const max = Number(input.max) || Infinity;
-    let quantity = Number(input.value) || min;
-
-    // Snap manual input to the closest allowed value
+    let quantity = Number(input.value);
+    if (Number.isNaN(quantity)) quantity = min;
     if (quantity > max) quantity = max;
-    if (quantity !== max) {
-      quantity = Math.floor((quantity - min) / step) * step + min;
-      if (quantity < min) quantity = min;
-    }
+    if (quantity < min) quantity = min;
 
     input.value = quantity;
     if (quantity >= max) {
@@ -8862,16 +8858,9 @@ _defineProperty(this, "handleQtyInputChange", e => {
   const attrMax = parseFloat(input.max);
   if (!Number.isNaN(attrMax)) max = attrMax;
 
-  let val = Number(input.value) || min;
-
-  const snapDown = v => {
-    if (!isFinite(v)) return min;
-    if (v < min) return min;
-    return Math.floor((v - min) / step) * step + min;
-  };
-
+  let val = Number(input.value);
+  if (Number.isNaN(val)) val = min;
   if (val > max) val = max;
-  if (val !== max) val = snapDown(val);
   if (val < min) val = min;
   input.value = val;
 

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -87,26 +87,46 @@ var LABEL_SUFFIX = '';
     });
   }
 
+  function clampAndHighlightQtyNoSnap(input){
+    var step = parseInt(input.getAttribute('data-min-qty'), 10) || parseInt(input.step,10) || 1;
+    var min = parseInt(input.min, 10) || step;
+    var max = input.max ? parseInt(input.max, 10) : Infinity;
+    var val = parseInt(input.value, 10);
+    val = isNaN(val) ? min : val;
+    if(val > max) val = max;
+    if(val < min) val = min;
+    input.value = val;
+    if(val >= max){
+      input.classList.add('text-red-600');
+      input.style.color = '#e3342f';
+    }else{
+      input.classList.remove('text-red-600');
+      input.style.color = '';
+    }
+    return val;
+  }
+
   function attachQtyInputListeners(){
-    var selectors = '.quantity-input__element, .scd-item__qty_input, input[data-quantity-input]';
+    var selectors = '.quantity-input__element, input[data-quantity-input]';
     document.querySelectorAll(selectors).forEach(function(input){
       if(input.dataset.qtyListener) return;
+      if(input.closest('.scd-item') || input.closest('[data-cart-item]')) return;
       input.dataset.qtyListener = '1';
       ['input','change','blur'].forEach(function(ev){
         input.addEventListener(ev, function(){
-          validateAndHighlightQty(input);
+          clampAndHighlightQtyNoSnap(input);
           updateIncreaseBtnState(input);
           syncOtherQtyInputs(input);
         });
       });
       input.addEventListener('keypress', function(e){
         if(e.key === 'Enter'){
-          validateAndHighlightQty(input);
+          clampAndHighlightQtyNoSnap(input);
           updateIncreaseBtnState(input);
           syncOtherQtyInputs(input);
         }
       });
-      validateAndHighlightQty(input);
+      clampAndHighlightQtyNoSnap(input);
       updateIncreaseBtnState(input);
       syncOtherQtyInputs(input);
     });


### PR DESCRIPTION
## Summary
- allow manual quantity edits between min and max
- skip rounding when editing manually
- ignore cart inputs in double-qty helper
- document how to reinit quantity inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68898e09c710832d95a2bdfe3dab349a