### PR TITLE
Hide empty error container

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -6,3 +6,50 @@
 .form__input-wrapper--select.flex-1 {
   margin-bottom: 0 !important;
 }
+
+/* Hide empty or hidden product form errors */
+.prod__form-error:empty,
+.prod__form-error[hidden] {
+  display: none;
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}
+
+.prod__form-error:not(:empty):not([hidden]) {
+  display: block;
+}
+
+/* Sticky ATC error styles */
+.sticky-atc-error {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  background: #dc2626;
+  color: #fff;
+  border: 1px solid #b91c1c;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem 0.25rem 0 0;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 9999;
+  transform: translateY(-100%);
+  opacity: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.sticky-atc-error.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.sticky-atc-error[hidden] {
+  display: none;
+}
+
+.sticky-atc-error__close {
+  margin-left: 0.75rem;
+  cursor: pointer;
+}

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -9,3 +9,50 @@
 .form__input-wrapper--select.flex-1 {
   margin-bottom: 0 !important;
 }
+
+/* Hide empty or hidden product form errors */
+.prod__form-error:empty,
+.prod__form-error[hidden] {
+  display: none;
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}
+
+.prod__form-error:not(:empty):not([hidden]) {
+  display: block;
+}
+
+/* Sticky ATC error styles */
+.sticky-atc-error {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  width: 100%;
+  background: #dc2626;
+  color: #fff;
+  border: 1px solid #b91c1c;
+  padding: 0.75rem 1rem;
+  border-radius: 0.25rem 0.25rem 0 0;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 9999;
+  transform: translateY(-100%);
+  opacity: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.sticky-atc-error.show {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.sticky-atc-error[hidden] {
+  display: none;
+}
+
+.sticky-atc-error__close {
+  margin-left: 0.75rem;
+  cursor: pointer;
+}

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1210,6 +1210,7 @@ if (!customElements.get('sticky-atc')) {
     connectedCallback() {
       this.productFormActions = document.querySelector('.add-to-cart');
       this.container = this.closest('.prod__sticky-atc');
+      this.errorDisplay = new StickyATCErrorDisplay(this.container);
       this.init();
     }
 
@@ -1248,6 +1249,14 @@ if (!customElements.get('sticky-atc')) {
 
       if (this.hasCustomFields) {
         atc.addEventListener("click", e => {
+          const missing = validateForm(this.mainProduct);
+          if (missing.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            this.errorDisplay?.show(window.ConceptSGMStrings.requiredField);
+            scrollToTop(() => this.mainATCButton.click());
+            return;
+          }
           e.preventDefault();
           e.stopPropagation();
           scrollToTop(() => this.mainATCButton.click());
@@ -1260,6 +1269,7 @@ if (!customElements.get('sticky-atc')) {
             if (missing.length > 0) {
               e.preventDefault();
               e.stopPropagation();
+              this.errorDisplay?.show(window.ConceptSGMStrings.requiredField);
               scrollToTop(() => this.mainProductDynamic?.click());
             }
           }, true);
@@ -1287,4 +1297,39 @@ if (!customElements.get('sticky-atc')) {
 }
 }();
 /******/ })()
+
+class StickyATCErrorDisplay {
+  constructor(bar) {
+    this.el = bar.querySelector('.sticky-atc-error');
+    this.timer = null;
+    if (this.el) {
+      this.el.addEventListener('click', e => {
+        if (e.target.closest('.sticky-atc-error__close')) {
+          this.hide();
+        }
+      });
+    }
+  }
+
+  show(message) {
+    if (!this.el) return;
+    clearTimeout(this.timer);
+    this.el.innerHTML = `<span>${message}</span><span class="sticky-atc-error__close">&times;</span>`;
+    this.el.removeAttribute('hidden');
+    requestAnimationFrame(() => {
+      this.el.classList.add('show');
+    });
+    this.timer = setTimeout(() => this.hide(), 4000);
+  }
+
+  hide() {
+    if (!this.el) return;
+    this.el.classList.remove('show');
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.el.setAttribute('hidden', '');
+      this.el.innerHTML = '';
+    }, 300);
+  }
+}
 ;

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -21,7 +21,7 @@
     endfor
   endif
 -%}
-<script src="{{ 'sticky-atc.min.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'sticky-atc.js' | asset_url }}" defer="defer"></script>
 <div
   class="prod__sticky-atc {{ class }} sf-prod__block fixed z-40 bottom-0 inset-x-0 transition-transform translate-y-full{% if enable_dynamic_checkout %} enable-dynamic-checkout{% endif %}"
   data-show-on-desktop="{{ st.use_sticky_atc }}"
@@ -45,6 +45,7 @@
         </div>
       </div>
       <div class="flex shrink-0 items-center psa__form-controls {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
+        <div class="sticky-atc-error" hidden></div>
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
         <product-form class="f-product-form w-full {{ image_field.size }}">


### PR DESCRIPTION
## Summary
- ensure product form error area is hidden when empty or hidden
- add sticky ATC error overlay with smooth animations

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6889ffbd811c832d82f99141ee86d997