### PR TITLE
Add sticky ATC inline error system

### DIFF
--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -20,3 +20,37 @@
 .prod__form-error:not(:empty) {
   display: block;
 }
+
+/* Sticky ATC error display */
+.sticky-atc-error {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: #ef4444;
+  color: #fff;
+  border: 1px solid #b91c1c;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transform: translateY(-100%);
+  opacity: 0;
+  z-index: 60;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+.sticky-atc-error.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.sticky-atc-error:empty {
+  display: none;
+}
+.sticky-atc-error button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  float: right;
+}

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -44,7 +44,7 @@
           </div>
         </div>
       </div>
-      <div class="flex shrink-0 items-center psa__form-controls {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
+      <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
         <product-form class="f-product-form w-full {{ image_field.size }}">
@@ -68,6 +68,7 @@
                 </option>
               {% endfor %}
             </select>
+            <div class="sticky-atc-error"></div>
             {%- capture qty_input_class -%}
               mr-2.5 lg:mr-5 lg:flex {% unless product.has_only_default_variant %}hidden{% endunless %}
             {%- endcapture -%}

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -21,7 +21,7 @@
     endfor
   endif
 -%}
-<script src="{{ 'sticky-atc.min.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'sticky-atc.js' | asset_url }}" defer="defer"></script>
 <div
   class="prod__sticky-atc {{ class }} sf-prod__block fixed z-40 bottom-0 inset-x-0 transition-transform translate-y-full{% if enable_dynamic_checkout %} enable-dynamic-checkout{% endif %}"
   data-show-on-desktop="{{ st.use_sticky_atc }}"


### PR DESCRIPTION
## Summary
- add `.sticky-atc-error` container in sticky-atc snippet
- style sticky ATC errors with slide/fade animation
- display sticky ATC errors via new `StickyATCError` class
- hook sticky ATC form events to use the new error display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a487cf064832dbe5ebcfa60414606