### PR TITLE
Add sticky ATC inline error system

### DIFF
--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -23,20 +23,17 @@
 
 /* Sticky ATC error display */
 .sticky-atc-error {
-  position: absolute;
-  top: -100%;
-  left: 50%;
-  width: 70%;
+  position: relative;
+  width: 80%;
   max-width: calc(var(--container-width, 1280) * 1px);
-  margin-left: 0;
-  margin-right: 0;
+  margin: 0 auto;
   padding: .5rem 1rem;
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;
   border-radius: 4px;
   box-shadow: 0 2px 6px #0003;
-  transform: translate(-50%, -100%);
+  transform: translateY(-100%);
   opacity: 0;
   z-index: 60;
   transition: transform .3s ease, opacity .3s ease;
@@ -44,7 +41,7 @@
 }
 .sticky-atc-error.show {
   opacity: 1;
-  transform: translate(-50%, 0);
+  transform: translateY(0);
 }
 .sticky-atc-error:empty {
   display: none;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -49,11 +49,13 @@
   display: none;
 }
 .sticky-atc-error button {
+  position: absolute;
+  top: 4px;
+  right: 6px;
   background: transparent;
   border: 0;
   color: inherit;
   font-size: 16px;
   line-height: 1;
   cursor: pointer;
-  float: right;
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -28,10 +28,10 @@
   left: 0;
   right: 0;
   width: auto;
-  padding: .5rem 1rem;
-  margin-left: 35px;
-  margin-right: 90px;
   max-width: calc(var(--container-width, 1280) * 1px);
+  margin-left: 2rem;
+  margin-right: 2rem;
+  padding: .5rem 1rem;
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;
@@ -41,6 +41,7 @@
   opacity: 0;
   z-index: 60;
   transition: transform .3s ease, opacity .3s ease;
+  pointer-events: auto;
 }
 .sticky-atc-error.show {
   opacity: 1;
@@ -48,4 +49,19 @@
 }
 .sticky-atc-error:empty {
   display: none;
+}
+.sticky-atc-error__msg {
+  display: block;
+  padding-right: 1.5rem;
+}
+.sticky-atc-error__close {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  border: none;
+  background: none;
+  color: #fff;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -24,9 +24,12 @@
 /* Sticky ATC error display */
 .sticky-atc-error {
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  top: -100%;
+  left: auto;
+  right: auto;
+  width: 80%;
+  margin-left: auto;
+  margin-right: auto;
   padding: 0.5rem 1rem;
   background: #ef4444;
   color: #fff;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -29,8 +29,9 @@
   right: 0;
   width: auto;
   padding: .5rem 1rem;
-  margin-left: 2rem;
-  margin-right: 2rem;
+  margin-left: 35px;
+  margin-right: 90px;
+  max-width: calc(var(--container-width, 1280) * 1px);
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -25,19 +25,18 @@
 .sticky-atc-error {
   position: absolute;
   top: -100%;
-  left: auto;
-  right: auto;
+  left: 50%;
   width: 80%;
   max-width: calc(var(--container-width, 1280) * 1px);
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: 0;
+  margin-right: 0;
   padding: .5rem 1rem;
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;
   border-radius: 4px;
   box-shadow: 0 2px 6px #0003;
-  transform: translateY(-100%);
+  transform: translate(-50%, -100%);
   opacity: 0;
   z-index: 60;
   transition: transform .3s ease, opacity .3s ease;
@@ -45,7 +44,7 @@
 }
 .sticky-atc-error.show {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(-50%, 0);
 }
 .sticky-atc-error:empty {
   display: none;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -26,7 +26,7 @@
   position: absolute;
   top: -100%;
   left: 50%;
-  width: 80%;
+  width: 70%;
   max-width: calc(var(--container-width, 1280) * 1px);
   margin-left: 0;
   margin-right: 0;
@@ -51,16 +51,4 @@
 }
 .sticky-atc-error__msg {
   display: block;
-  padding-right: 1.5rem;
-}
-.sticky-atc-error__close {
-  position: absolute;
-  top: 2px;
-  right: 4px;
-  border: none;
-  background: none;
-  color: #fff;
-  font-size: 1rem;
-  line-height: 1;
-  cursor: pointer;
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -25,21 +25,21 @@
 .sticky-atc-error {
   position: absolute;
   top: -100%;
-  left: auto;
-  right: auto;
-  width: 80%;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 0.5rem 1rem;
+  left: 0;
+  right: 0;
+  width: auto;
+  padding: .5rem 1rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;
   border-radius: 4px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 6px #0003;
   transform: translateY(-100%);
   opacity: 0;
   z-index: 60;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  transition: transform .3s ease, opacity .3s ease;
 }
 .sticky-atc-error.show {
   opacity: 1;
@@ -47,15 +47,4 @@
 }
 .sticky-atc-error:empty {
   display: none;
-}
-.sticky-atc-error button {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  background: transparent;
-  border: 0;
-  color: inherit;
-  font-size: 16px;
-  line-height: 1;
-  cursor: pointer;
 }

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -25,12 +25,12 @@
 .sticky-atc-error {
   position: absolute;
   top: -100%;
-  left: 0;
-  right: 0;
-  width: auto;
+  left: auto;
+  right: auto;
+  width: 80%;
   max-width: calc(var(--container-width, 1280) * 1px);
-  margin-left: 2rem;
-  margin-right: 2rem;
+  margin-left: auto;
+  margin-right: auto;
   padding: .5rem 1rem;
   background: #ef4444;
   color: #fff;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -23,17 +23,20 @@
 
 /* Sticky ATC error display */
 .sticky-atc-error {
-  position: relative;
-  width: 80%;
+  position: fixed;
+  left: 50%;
+  width: 70%;
   max-width: calc(var(--container-width, 1280) * 1px);
-  margin: 0 auto;
+  margin-left: 0;
+  margin-right: 0;
+  bottom: 90px;
   padding: .5rem 1rem;
   background: #ef4444;
   color: #fff;
   border: 1px solid #b91c1c;
   border-radius: 4px;
   box-shadow: 0 2px 6px #0003;
-  transform: translateY(-100%);
+  transform: translate(-50%, -100%);
   opacity: 0;
   z-index: 60;
   transition: transform .3s ease, opacity .3s ease;
@@ -41,7 +44,7 @@
 }
 .sticky-atc-error.show {
   opacity: 1;
-  transform: translateY(0);
+  transform: translate(-50%, 0);
 }
 .sticky-atc-error:empty {
   display: none;

--- a/assets/custom.css.liquid
+++ b/assets/custom.css.liquid
@@ -20,3 +20,37 @@
 .prod__form-error:not(:empty) {
   display: block;
 }
+
+/* Sticky ATC error display */
+.sticky-atc-error {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: #ef4444;
+  color: #fff;
+  border: 1px solid #b91c1c;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transform: translateY(-100%);
+  opacity: 0;
+  z-index: 60;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+.sticky-atc-error.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+.sticky-atc-error:empty {
+  display: none;
+}
+.sticky-atc-error button {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  float: right;
+}

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -27,6 +27,32 @@ const ConceptSGMSettings = window.ConceptSGMSettings || {};
 const ConceptSGMStrings = window.ConceptSGMStrings || {};
 const ConceptSGMLibs = window.ConceptSGMLibs || {};
 
+class StickyATCError {
+  constructor(node) {
+    this.node = node;
+    this.timer = null;
+  }
+  show(msg) {
+    if (!this.node) return;
+    clearTimeout(this.timer);
+    console.log('StickyATCError show', msg);
+    this.node.innerHTML = `<span>${msg}</span><button type="button" class="sticky-atc-error-close">&times;</button>`;
+    this.node.classList.add('show');
+    const btn = this.node.querySelector('.sticky-atc-error-close');
+    btn.addEventListener('click', () => this.hide());
+    this.timer = setTimeout(() => this.hide(), 4000);
+  }
+  hide() {
+    if (!this.node) return;
+    console.log('StickyATCError hide');
+    this.node.classList.remove('show');
+    this.timer = setTimeout(() => {
+      this.node.innerHTML = '';
+    }, 300);
+  }
+}
+window.StickyATCError = StickyATCError;
+
 /***/ }),
 
 /***/ 9280:
@@ -1349,30 +1375,5 @@ if (!customElements.get('sticky-atc')) {
 }
 }();
 /******/ })()
-class StickyATCError {
-  constructor(node) {
-    this.node = node;
-    this.timer = null;
-  }
-  show(msg) {
-    if (!this.node) return;
-    clearTimeout(this.timer);
-    console.log('StickyATCError show', msg);
-    this.node.innerHTML = `<span>${msg}</span><button type="button" class="sticky-atc-error-close">&times;</button>`;
-    this.node.classList.add('show');
-    const btn = this.node.querySelector('.sticky-atc-error-close');
-    btn.addEventListener('click', () => this.hide());
-    this.timer = setTimeout(() => this.hide(), 4000);
-  }
-  hide() {
-    if (!this.node) return;
-    console.log('StickyATCError hide');
-    this.node.classList.remove('show');
-    this.timer = setTimeout(() => {
-      this.node.innerHTML = '';
-    }, 300);
-  }
-}
-window.StickyATCError = StickyATCError;
 console.log('sticky-atc script loaded');
 ;

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -35,6 +35,7 @@ class StickyATCError {
   show(msg) {
     if (!this.node) return;
     clearTimeout(this.timer);
+    if (!msg) msg = window.ConceptSGMStrings.cartError || 'Error';
     console.log('StickyATCError show', msg);
     this.node.innerHTML = `<span>${msg}</span><button type="button" class="sticky-atc-error-close">&times;</button>`;
     this.node.classList.add('show');
@@ -1348,7 +1349,13 @@ if (!customElements.get('sticky-atc')) {
           .then(({ statusCode, body }) => {
             console.log('ATC response body', body);
             if (statusCode >= 400 || body.status) {
-              this.stickyError?.show(body.description || body.message);
+              let msg = body.description || body.message;
+              if (!msg && body.errors) {
+                if (typeof body.errors === 'string') msg = body.errors;
+                else if (Array.isArray(body.errors)) msg = body.errors[0];
+                else if (body.errors.base) msg = body.errors.base[0];
+              }
+              this.stickyError?.show(msg);
             } else {
               window.ConceptSGMEvents.emit('ON_ITEM_ADDED', body);
               window.Shopify.onItemAdded(body);

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1248,7 +1248,10 @@ if (!customElements.get('sticky-atc')) {
     connectedCallback() {
       this.productFormActions = document.querySelector('.add-to-cart');
       this.container = this.closest('.prod__sticky-atc');
-      this.errorWrapper = this.container?.querySelector('.sticky-atc-error');
+      this.errorWrapper = this.container?.previousElementSibling;
+      if (!(this.errorWrapper && this.errorWrapper.classList.contains('sticky-atc-error'))) {
+        this.errorWrapper = this.container?.querySelector('.sticky-atc-error');
+      }
       if (window.StickyATCError && this.errorWrapper) {
         this.stickyError = new window.StickyATCError(this.errorWrapper);
       }

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1240,7 +1240,7 @@ if (!customElements.get('sticky-atc')) {
       console.log('productFormActions', this.productFormActions);
       this.container = this.closest('.prod__sticky-atc');
       console.log('sticky atc container', this.container);
-      this.errorWrapper = this.querySelector('.sticky-atc-error');
+      this.errorWrapper = this.container?.querySelector('.sticky-atc-error');
       if (!this.errorWrapper) {
         console.warn('sticky-atc-error container not found');
       }

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -38,15 +38,6 @@ class StickyATCError {
         this.msgEl.className = 'sticky-atc-error__msg';
         this.node.append(this.msgEl);
       }
-      this.closeBtn = this.node.querySelector('.sticky-atc-error__close');
-      if (!this.closeBtn) {
-        this.closeBtn = document.createElement('button');
-        this.closeBtn.setAttribute('type', 'button');
-        this.closeBtn.className = 'sticky-atc-error__close';
-        this.closeBtn.innerHTML = '&times;';
-        this.node.append(this.closeBtn);
-      }
-      this.closeBtn.addEventListener('click', () => this.hide());
     }
   }
   removeDiacritics(text) {

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -31,6 +31,23 @@ class StickyATCError {
   constructor(node) {
     this.node = node;
     this.timer = null;
+    if (this.node) {
+      this.msgEl = this.node.querySelector('.sticky-atc-error__msg');
+      if (!this.msgEl) {
+        this.msgEl = document.createElement('span');
+        this.msgEl.className = 'sticky-atc-error__msg';
+        this.node.append(this.msgEl);
+      }
+      this.closeBtn = this.node.querySelector('.sticky-atc-error__close');
+      if (!this.closeBtn) {
+        this.closeBtn = document.createElement('button');
+        this.closeBtn.setAttribute('type', 'button');
+        this.closeBtn.className = 'sticky-atc-error__close';
+        this.closeBtn.innerHTML = '&times;';
+        this.node.append(this.closeBtn);
+      }
+      this.closeBtn.addEventListener('click', () => this.hide());
+    }
   }
   removeDiacritics(text) {
     return text && text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
@@ -40,7 +57,7 @@ class StickyATCError {
     clearTimeout(this.timer);
     if (!msg) msg = window.ConceptSGMStrings.cartError || 'Error';
     msg = this.removeDiacritics(msg);
-    this.node.textContent = msg;
+    this.msgEl.textContent = msg;
     this.node.classList.remove('show');
     void this.node.offsetWidth;
     this.node.classList.add('show');
@@ -49,8 +66,9 @@ class StickyATCError {
   hide() {
     if (!this.node) return;
     this.node.classList.remove('show');
+    clearTimeout(this.timer);
     this.timer = setTimeout(() => {
-      this.node.textContent = '';
+      this.msgEl.textContent = '';
     }, 300);
   }
 }

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -40,17 +40,17 @@ class StickyATCError {
     clearTimeout(this.timer);
     if (!msg) msg = window.ConceptSGMStrings.cartError || 'Error';
     msg = this.removeDiacritics(msg);
-    this.node.innerHTML = `<span>${msg}</span><button type="button" class="sticky-atc-error-close">&times;</button>`;
+    this.node.textContent = msg;
+    this.node.classList.remove('show');
+    void this.node.offsetWidth;
     this.node.classList.add('show');
-    const btn = this.node.querySelector('.sticky-atc-error-close');
-    btn.addEventListener('click', () => this.hide());
     this.timer = setTimeout(() => this.hide(), 4000);
   }
   hide() {
     if (!this.node) return;
     this.node.classList.remove('show');
     this.timer = setTimeout(() => {
-      this.node.innerHTML = '';
+      this.node.textContent = '';
     }, 300);
   }
 }
@@ -1272,6 +1272,9 @@ if (!customElements.get('sticky-atc')) {
           const method = entry.intersectionRatio !== 1 ? 'remove' : 'add';
           this.container.classList[method]('translate-y-full');
           document.documentElement.classList[entry.intersectionRatio != 1 ? 'remove' : 'add']('stick-atc-show');
+          if (entry.intersectionRatio === 1) {
+            this.stickyError?.hide();
+          }
         });
       }, {
         threshold: 1,

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1350,11 +1350,16 @@ if (!customElements.get('sticky-atc')) {
             console.log('ATC response body', body);
             if (statusCode >= 400 || body.status) {
               let msg = body.description || body.message;
-              if (!msg && body.errors) {
-                if (typeof body.errors === 'string') msg = body.errors;
-                else if (Array.isArray(body.errors)) msg = body.errors[0];
-                else if (body.errors.base) msg = body.errors.base[0];
+              const errData = body.errors;
+              if (!msg && errData) {
+                if (typeof errData === 'string') msg = errData;
+                else if (Array.isArray(errData)) msg = errData[0];
+                else if (typeof errData === 'object') {
+                  const key = Object.keys(errData)[0];
+                  msg = Array.isArray(errData[key]) ? errData[key][0] : errData[key];
+                }
               }
+              console.log('resolved atc error msg', msg);
               this.stickyError?.show(msg);
             } else {
               window.ConceptSGMEvents.emit('ON_ITEM_ADDED', body);

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1363,6 +1363,9 @@ if (!customElements.get('sticky-atc')) {
             console.log('ATC response body', body);
             if (statusCode >= 400 || body.status) {
               let msg = body.description || body.message || statusText;
+              if (msg && typeof msg === 'string' && /<\/?html/i.test(msg)) {
+                msg = window.ConceptSGMStrings.cartError || 'Error';
+              }
               const errData = body.errors;
               if (!msg && errData) {
                 if (typeof errData === 'string') msg = errData;
@@ -1381,7 +1384,10 @@ if (!customElements.get('sticky-atc')) {
           })
           .catch(err => {
             console.error('ATC fetch error', err);
-            const msg = window.ConceptSGMStrings.cartError || err.message || 'Error';
+            let msg = err && err.message || '';
+            if (!msg || /<\/?html/i.test(msg)) {
+              msg = window.ConceptSGMStrings.cartError || 'Error';
+            }
             this.stickyError?.show(msg);
           });
       } else {

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -1208,17 +1208,25 @@ if (!customElements.get('sticky-atc')) {
     }
 
     connectedCallback() {
+      console.log('StickyATC connected');
       this.productFormActions = document.querySelector('.add-to-cart');
+      console.log('productFormActions', this.productFormActions);
       this.container = this.closest('.prod__sticky-atc');
+      console.log('sticky atc container', this.container);
       this.errorWrapper = this.querySelector('.sticky-atc-error');
+      if (!this.errorWrapper) {
+        console.warn('sticky-atc-error container not found');
+      }
       if (window.StickyATCError && this.errorWrapper) {
         this.stickyError = new window.StickyATCError(this.errorWrapper);
       }
       this.form = this.querySelector('form');
+      console.log('sticky atc form', this.form);
       this.init();
     }
 
     init() {
+      console.log('StickyATC init');
       this.mainProduct = document.querySelector('.main-product.product-form');
       this.mainATCButton = this.mainProduct?.querySelector('.add-to-cart');
       this.mainProductDynamic = this.mainProduct?.querySelector(this.selectors.buyNowBtn);
@@ -1276,6 +1284,7 @@ if (!customElements.get('sticky-atc')) {
       this.setObserveTarget();
       this.syncWithMainProductForm();
       if (this.form && this.stickyError) {
+        console.log('attaching submit listener to sticky form');
         this.form.addEventListener('submit', this.handleSubmit.bind(this), true);
       }
     }
@@ -1286,10 +1295,12 @@ if (!customElements.get('sticky-atc')) {
     }
 
     handleSubmit(e) {
+      console.log('sticky atc handleSubmit');
       e.preventDefault();
       e.stopPropagation();
       const missing = validateForm(this.mainProduct || this.form);
       if (missing && missing.length > 0) {
+        console.log('sticky atc validation missing', missing);
         this.stickyError?.show(window.ConceptSGMStrings.requiredField);
         return;
       }
@@ -1303,14 +1314,18 @@ if (!customElements.get('sticky-atc')) {
       };
       const { ConceptSGMSettings } = window;
       if (ConceptSGMSettings.use_ajax_atc) {
-        fetch(`${ConceptSGMSettings.routes.cart_add_url}`, config).then(r => r.json()).then(res => {
+        fetch(`${ConceptSGMSettings.routes.cart_add_url}`, config).then(r => {
+          console.log('ATC response status', r.status);
+          return r.json();
+        }).then(res => {
+          console.log('ATC response body', res);
           if (res.status) {
             this.stickyError?.show(res.description);
           } else {
             window.ConceptSGMEvents.emit('ON_ITEM_ADDED', res);
             window.Shopify.onItemAdded(res);
           }
-        }).catch(err => console.error(err));
+        }).catch(err => console.error('ATC fetch error', err));
       } else {
         this.form.submit();
       }
@@ -1319,7 +1334,7 @@ if (!customElements.get('sticky-atc')) {
     syncWithMainProductForm() {
       const variantInput = this.querySelector('[name="id"]');
       window.ConceptSGMEvents.subscribe(`${this.productId}__VARIANT_CHANGE`, async variant => {
-        console.log('variant change');
+        console.log('sticky atc variant change', variant);
         variantInput.value = variant.id;
       });
     }
@@ -1336,6 +1351,7 @@ class StickyATCError {
   show(msg) {
     if (!this.node) return;
     clearTimeout(this.timer);
+    console.log('StickyATCError show', msg);
     this.node.innerHTML = `<span>${msg}</span><button type="button" class="sticky-atc-error-close">&times;</button>`;
     this.node.classList.add('show');
     const btn = this.node.querySelector('.sticky-atc-error-close');
@@ -1344,6 +1360,7 @@ class StickyATCError {
   }
   hide() {
     if (!this.node) return;
+    console.log('StickyATCError hide');
     this.node.classList.remove('show');
     this.timer = setTimeout(() => {
       this.node.innerHTML = '';

--- a/snippets/scroll-top-button.liquid
+++ b/snippets/scroll-top-button.liquid
@@ -6,6 +6,7 @@
       display: inline-flex;
       width: 46px;
       height: 46px;
+      z-index: 80;
     }
     @media (max-width: 767px) {
       #scroll-to-top-button {

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -22,6 +22,7 @@
   endif
 -%}
 <script src="{{ 'sticky-atc.js' | asset_url }}" defer="defer"></script>
+<div class="sticky-atc-error" aria-live="polite"><span class="sticky-atc-error__msg"></span></div>
 <div
   class="prod__sticky-atc {{ class }} sf-prod__block fixed z-40 bottom-0 inset-x-0 transition-transform translate-y-full{% if enable_dynamic_checkout %} enable-dynamic-checkout{% endif %}"
   data-show-on-desktop="{{ st.use_sticky_atc }}"
@@ -29,7 +30,6 @@
   style="box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.09);"
   data-view="sticky-atc"
 >
-  <div class="sticky-atc-error" aria-live="polite"><span class="sticky-atc-error__msg"></span></div>
   <div class="{{ st.container }}{% if st.container == 'w-full' %} px-4{% endif %}">
     <sticky-atc class="form product-form lg:container flex items-center justify-between" data-product-id="{{ product.id }}">
       <div class="{% if product.has_only_default_variant %} flex {% else %} hidden {% endif %} md:flex pr-2">

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -30,7 +30,6 @@
   data-view="sticky-atc"
 >
   <div class="{{ st.container }}{% if st.container == 'w-full' %} px-4{% endif %}">
-    <div class="sticky-atc-error"></div>
     <sticky-atc class="form product-form lg:container flex items-center justify-between" data-product-id="{{ product.id }}">
       <div class="{% if product.has_only_default_variant %} flex {% else %} hidden {% endif %} md:flex pr-2">
         <div class="spc__main-img cursor-pointer py-1.5">
@@ -46,6 +45,7 @@
         </div>
       </div>
       <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
+        <div class="sticky-atc-error" aria-live="polite"></div>
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
         <product-form class="f-product-form w-full {{ image_field.size }}">

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -47,6 +47,7 @@
       <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
+        <div class="sticky-atc-error"></div>
         <product-form class="f-product-form w-full {{ image_field.size }}">
           {%- form 'product', product, id: product_form_id, class: product_form_class, novalidate: 'novalidate', data-type: 'add-to-cart-form', data-preorder: is_preorder -%}
             <select
@@ -68,7 +69,6 @@
                 </option>
               {% endfor %}
             </select>
-            <div class="sticky-atc-error"></div>
             {%- capture qty_input_class -%}
               mr-2.5 lg:mr-5 lg:flex {% unless product.has_only_default_variant %}hidden{% endunless %}
             {%- endcapture -%}

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -21,7 +21,7 @@
     endfor
   endif
 -%}
-<script src="{{ 'sticky-atc.min.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'sticky-atc.js' | asset_url }}" defer="defer"></script>
 <div
   class="prod__sticky-atc {{ class }} sf-prod__block fixed z-40 bottom-0 inset-x-0 transition-transform translate-y-full{% if enable_dynamic_checkout %} enable-dynamic-checkout{% endif %}"
   data-show-on-desktop="{{ st.use_sticky_atc }}"
@@ -44,7 +44,7 @@
           </div>
         </div>
       </div>
-      <div class="flex shrink-0 items-center psa__form-controls {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
+      <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
         <product-form class="f-product-form w-full {{ image_field.size }}">
@@ -68,6 +68,7 @@
                 </option>
               {% endfor %}
             </select>
+            <div class="sticky-atc-error"></div>
             {%- capture qty_input_class -%}
               mr-2.5 lg:mr-5 lg:flex {% unless product.has_only_default_variant %}hidden{% endunless %}
             {%- endcapture -%}

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -30,6 +30,7 @@
   data-view="sticky-atc"
 >
   <div class="{{ st.container }}{% if st.container == 'w-full' %} px-4{% endif %}">
+    <div class="sticky-atc-error" aria-live="polite"></div>
     <sticky-atc class="form product-form lg:container flex items-center justify-between" data-product-id="{{ product.id }}">
       <div class="{% if product.has_only_default_variant %} flex {% else %} hidden {% endif %} md:flex pr-2">
         <div class="spc__main-img cursor-pointer py-1.5">
@@ -45,7 +46,6 @@
         </div>
       </div>
       <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
-        <div class="sticky-atc-error" aria-live="polite"></div>
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
         <product-form class="f-product-form w-full {{ image_field.size }}">

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -29,8 +29,8 @@
   style="box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.09);"
   data-view="sticky-atc"
 >
+  <div class="sticky-atc-error" aria-live="polite"><span class="sticky-atc-error__msg"></span></div>
   <div class="{{ st.container }}{% if st.container == 'w-full' %} px-4{% endif %}">
-    <div class="sticky-atc-error" aria-live="polite"></div>
     <sticky-atc class="form product-form lg:container flex items-center justify-between" data-product-id="{{ product.id }}">
       <div class="{% if product.has_only_default_variant %} flex {% else %} hidden {% endif %} md:flex pr-2">
         <div class="spc__main-img cursor-pointer py-1.5">

--- a/snippets/sticky-atc.liquid
+++ b/snippets/sticky-atc.liquid
@@ -30,6 +30,7 @@
   data-view="sticky-atc"
 >
   <div class="{{ st.container }}{% if st.container == 'w-full' %} px-4{% endif %}">
+    <div class="sticky-atc-error"></div>
     <sticky-atc class="form product-form lg:container flex items-center justify-between" data-product-id="{{ product.id }}">
       <div class="{% if product.has_only_default_variant %} flex {% else %} hidden {% endif %} md:flex pr-2">
         <div class="spc__main-img cursor-pointer py-1.5">
@@ -47,7 +48,6 @@
       <div class="flex shrink-0 items-center psa__form-controls relative {% unless product.has_only_default_variant %} w-full md:w-auto{% endunless %}">
         {%- assign product_form_id = 'sticky-atc-form-' | append: section.id -%}
         {%- assign product_form_class = 'sticky-atc-form flex product-form-' | append: section.id -%}
-        <div class="sticky-atc-error"></div>
         <product-form class="f-product-form w-full {{ image_field.size }}">
           {%- form 'product', product, id: product_form_id, class: product_form_class, novalidate: 'novalidate', data-type: 'add-to-cart-form', data-preorder: is_preorder -%}
             <select

--- a/templates/product.json
+++ b/templates/product.json
@@ -45,7 +45,7 @@
           "type": "buy_buttons",
           "settings": {
             "show_quantity_selector": true,
-            "show_double_qty_btn": false,
+            "show_double_qty_btn": true,
             "show_atc_button": true,
             "show_dynamic_checkout": false
           }

--- a/templates/product.json
+++ b/templates/product.json
@@ -45,7 +45,7 @@
           "type": "buy_buttons",
           "settings": {
             "show_quantity_selector": true,
-            "show_double_qty_btn": true,
+            "show_double_qty_btn": false,
             "show_atc_button": true,
             "show_dynamic_checkout": false
           }


### PR DESCRIPTION
## Summary
- add `.sticky-atc-error` container in sticky-atc snippet
- style sticky ATC errors with slide/fade animation
- display sticky ATC errors via new `StickyATCError` class
- hook sticky ATC form events to use the new error display
- load non-minified sticky ATC script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a487cf064832dbe5ebcfa60414606