### PR TITLE
Display unit price and line total in cart

### DIFF
--- a/snippets/cart-drawer-item.liquid
+++ b/snippets/cart-drawer-item.liquid
@@ -88,6 +88,12 @@
         </span>
         </div>
       </div>
+      <div class="cart-item-unit-price text-sm">
+        {{ item.final_price | money }} / buc
+      </div>
+      <div class="cart-item-line-total text-sm">
+        Total: {{ item.final_line_price | money }}
+      </div>
 
       {%- if item.discounts.size > 0 -%}
         <ul class="scd-item__discounts flex" role="list">

--- a/snippets/cart-line-item.liquid
+++ b/snippets/cart-line-item.liquid
@@ -164,9 +164,12 @@
           <span data-unit-price-base-unit>{{- unit_price_base_unit -}}</span>
         </span>
       </div>
-    </div>
+      </div>
+      <div class="cart-item-unit-price text-sm">
+        {{ item.final_price | money }} / buc
+      </div>
 
-    {%- assign item_discounts = 'template ' | split: ' ' -%}
+      {%- assign item_discounts = 'template ' | split: ' ' -%}
     {%- if item.line_level_discount_allocations != blank -%}
       {%- assign item_discounts = item.line_level_discount_allocations -%}
     {%- endif -%}
@@ -266,6 +269,9 @@
           {{ item.original_line_price | money }}
         {%- endif -%}
       </span>
+    </div>
+    <div class="cart-item-line-total text-sm">
+      Total: {{ item.final_line_price | money }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add unit price and line total in drawer cart items
- show unit price and line total on full cart page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `bundle exec theme-check` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5977b04832daf9d16c06fda59e5