### PR TITLE
Limit product titles to one line

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -17,3 +17,12 @@
 .prod__form-error:not(:empty) {
   display: block;
 }
+
+/* Enforce single-line truncation for product card titles */
+.sf__pcard-name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}


### PR DESCRIPTION
## Summary
- keep product card names to a single line using ellipsis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688adad584c4832db7a0332dd3e32a1e