### PR TITLE
Make double quantity button label configurable per block

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -399,6 +399,13 @@
           "default": true,
           "label": "Show dynamic checkout buttons",
           "info": "Using the payment methods available on your store, customers see their preferred option, like PayPal or Apple Pay. [Learn more](https://help.shopify.com/manual/using-themes/change-the-layout/dynamic-checkout)"
+        },
+        {
+          "type": "text",
+          "id": "double_qty_btn_label",
+          "label": "Double quantity button text",
+          "default": "Add another {min_qty}",
+          "info": "You can use {min_qty} to insert the minimum quantity. Example: Add another {min_qty} units!"
         }
       ]
     },

--- a/snippets/double-qty-btn.liquid
+++ b/snippets/double-qty-btn.liquid
@@ -9,7 +9,7 @@
 {% elsif item %}
   {% assign min_qty = item.product.metafields.custom.minimum_quantity | default: 1 %}
 {% endif %}
-{% assign label_template = settings.double_qty_btn_label | default: 'Add another {min_qty}' %}
+{% assign label_template = block.settings.double_qty_btn_label | default: 'Add another {min_qty}' %}
 {% if label_template contains '{min_qty}' %}
   {% assign btn_label = label_template | replace: '{min_qty}', min_qty %}
 {% else %}

--- a/snippets/main-product-blocks.liquid
+++ b/snippets/main-product-blocks.liquid
@@ -332,7 +332,7 @@
       <div class="flex flex-wrap items-end{% unless has_double_qty_btn %} gap-2{% endunless %}">
         {% if block.settings.show_quantity_selector %}
           <div class="form__input-wrapper form__input-wrapper--select{% if has_double_qty_btn %} mr-5 w-32{% else %} flex-1{% endif %}" data-quantity-input-wrapper>
-            {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: block.settings.show_double_qty_btn %}
+            {% render 'product-qty-input', product_form_id: product_form_id, show_double_qty_btn: block.settings.show_double_qty_btn, block: block %}
           </div>
                       {% endif %}
                       {% if block.settings.show_atc_button %}

--- a/snippets/product-qty-input.liquid
+++ b/snippets/product-qty-input.liquid
@@ -41,7 +41,7 @@
 
   {%- if show_double_qty_btn -%}
     {%- assign min_qty = product.metafields.custom.minimum_quantity | default: 1 -%}
-    {%- assign label_template = settings.double_qty_btn_label | default: 'Add another {min_qty}' -%}
+    {%- assign label_template = block.settings.double_qty_btn_label | default: 'Add another {min_qty}' -%}
     {%- if label_template contains '{min_qty}' -%}
       {%- assign btn_label = label_template | replace: '{min_qty}', min_qty -%}
     {%- else -%}


### PR DESCRIPTION
## Summary
- add per-block setting for double quantity button text in main-product section
- adjust product-qty-input and double-qty-btn snippets to read the label from the block
- pass the block object when rendering product-qty-input

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ba7b93598832d87869600b9a11082