### PR TITLE
feat: adjust double qty button increment

### DIFF
--- a/assets/double-qty.css
+++ b/assets/double-qty.css
@@ -20,6 +20,11 @@
   outline: none;
 }
 
+/* Efect de mărire la hover */
+.double-qty-btn:hover:not(:disabled) {
+  transform: scale(1.03);
+}
+
 /* Efect fizic de apăsare la click, doar dacă nu e dezactivat */
 .double-qty-btn:active:not(:disabled) {
   transform: scale(0.98);

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -243,7 +243,17 @@ var BUTTON_CLASS = 'double-qty-btn';
 
       btn.addEventListener('click', function(e){
         e.preventDefault();
-        adjustQuantity(input, 1);
+        var step = parseInt(input.getAttribute('data-min-qty'), 10) || parseInt(input.step,10) || 1;
+        var max = input.max ? parseInt(input.max, 10) : Infinity;
+        var current = parseInt(input.value, 10);
+        if(isNaN(current)) current = 0;
+        var newVal = current + step;
+        if(newVal > max) newVal = max;
+        input.value = newVal;
+        validateAndHighlightQty(input);
+        updateQtyButtonsState(input);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
         updateBtnState();
       });
 


### PR DESCRIPTION
## Summary
- ensure double-qty-btn increments quantity by minimum step and clamps to stock

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e700c022c832d98de9102ff63f6fb