### PR TITLE
Ensure double-qty button label remains fixed

### DIFF
--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -271,7 +271,14 @@ var BUTTON_CLASS = 'double-qty-btn';
     document.querySelectorAll('.' + BUTTON_CLASS).forEach(function(btn){
       var input = findQtyInput(btn);
       if (!input) return;
-      var min = parseInt(input.getAttribute('data-min-qty'), 10) || 1;
+      var storedMin = parseInt(btn.getAttribute('data-original-min-qty'), 10);
+      var min;
+      if(isNaN(storedMin)){
+        min = parseInt(input.getAttribute('data-min-qty'), 10) || 1;
+        btn.setAttribute('data-original-min-qty', min);
+      }else{
+        min = storedMin;
+      }
       var template = btn.getAttribute('data-label-template') || btn.textContent;
       var label = template.replace('{min_qty}', min);
       btn.setAttribute('aria-label', label);


### PR DESCRIPTION
## Summary
- retain original minimum quantity on the double-qty button
- use the stored minimum to consistently display "Adaugă încă X"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc342dffc832d9c28e27577f89c81