### PR TITLE
feat(cart): warn when max quantity reached

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -7028,7 +7028,8 @@ class Cart {
     _defineProperty(this, "changeItemQty", async lineItem => {
       const {
         not_enough_item_message,
-        sold_out_items_message
+        sold_out_items_message,
+        cartLimit
       } = cart_ConceptSGMStrings;
 
       try {
@@ -7036,6 +7037,7 @@ class Cart {
           id: key,
           quantity
         } = lineItem;
+        const prevItem = this.getCartItemByKey(key);
         this.loading.start();
         const newCart = await this.changeCart(lineItem);
         this.cart = newCart;
@@ -7063,10 +7065,12 @@ class Cart {
 
             if (lineItems.length === 1) {
               const lineItemNode = this.getLineItemNode(lineItem);
+              const reachedLimit = prevItem?.quantity === newItem.quantity;
+              const message = reachedLimit ? cartLimit || 'Ai atins limita maximă disponibilă pentru acest produs.' : not_enough_item_message.replace('__inventory_quantity__', newItem.quantity);
               cart_ConceptSGMTheme.Notification.show({
                 target: lineItemNode,
                 type: 'warning',
-                message: not_enough_item_message.replace('__inventory_quantity__', newItem.quantity)
+                message
               });
             }
           }

--- a/snippets/theme-data.liquid
+++ b/snippets/theme-data.liquid
@@ -60,6 +60,7 @@ window.ConceptSGMStrings = {
   preorder: "{% render 'new-locale', key: 'products.product.preorder' %}",
   not_enough_item_message: "{{ 'products.product.not_enough_items_message' | t: quantity: '__inventory_quantity__' }}",
   sold_out_items_message: "{{ 'products.product.sold_out_items_message' | t }}",
+  cartLimit: "Ai atins limita maximă disponibilă pentru acest produs.",
   unitPrice: {{ 'products.product.unit_price_label' | t | json }},
   unitPriceSeparator: {{ 'general.accessibility.unit_price_separator' | t | json }}
 };


### PR DESCRIPTION
## Summary
- add `cartLimit` translation string for cart limit messages
- warn in cart drawer when a product's maximum quantity is already in cart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd497520c832da6be8f37ac7d69eb