### PR TITLE
Match collection quick add button styling to product form

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -24,10 +24,10 @@ input.collection-qty-element:focus {
   padding: 0.5rem 0.75rem;
 }
 
-.collection-product-form .collection-atc-spinner { display: none; }
-.collection-product-form.adding .collection-atc-spinner { display: flex; }
-.collection-product-form.adding .collection-atc-text { visibility: hidden; }
-.collection-product-form.adding .collection-add-to-cart { pointer-events: none; }
+.collection-product-form .atc-spinner { display: none; }
+.collection-product-form.adding .atc-spinner { display: flex; }
+.collection-product-form.adding .atc-text { visibility: hidden; }
+.collection-product-form.adding .add-to-cart { pointer-events: none; }
 
 /* prevent text highlighting on quick-add buttons */
 .sf__pcard-quick-add-col .collection-add-to-cart,

--- a/assets/double-qty.js
+++ b/assets/double-qty.js
@@ -269,6 +269,7 @@ var BUTTON_CLASS = 'double-qty-btn';
 
   function initDoubleQtyButtons() {
     document.querySelectorAll('.' + BUTTON_CLASS).forEach(function(btn){
+      if (btn.hasAttribute('data-collection-double-qty') || btn.classList.contains('collection-double-qty-btn')) return;
       var input = findQtyInput(btn);
       if (!input) return;
       var storedMin = parseInt(btn.getAttribute('data-original-min-qty'), 10);

--- a/snippets/collection-quick-add.liquid
+++ b/snippets/collection-quick-add.liquid
@@ -46,15 +46,7 @@
                 {%- endif -%}
               </div>
             </div>
-            <button type="submit" name="add" class="collection-add-to-cart sf__btn flex-grow shrink not-change relative sf__btn-secondary sf__btn-white w-full mt-4" data-collection-atc-text="{{ 'products.product.add_to_cart' | t }}" aria-label="{{ 'products.product.add_to_cart' | t }}">
-              <span class="collection-atc-spinner inset-0 absolute items-center justify-center">
-                <svg class="animate-spin w-[20px] h-[20px]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                </svg>
-              </span>
-              <span class="not-change collection-atc-text">{{ 'products.product.add_to_cart' | t }}</span>
-            </button>
+            {% render 'product-atc', class: 'collection-add-to-cart sf__btn-primary w-full mt-4', product: product %}
           </div>
           <input type="hidden" name="product-id" value="{{ product.id }}">
           <input type="hidden" name="section-id" value="{{ section.id }}">


### PR DESCRIPTION
## Summary
- render shared product-atc snippet for collection quick add button
- use primary button classes so collection add-to-cart mirrors product form styling
- skip `.collection-double-qty-btn` elements in global double-qty handler so quick add only increases by the minimum amount once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68910487bcc4832d938a28f60c4e786e