### PR TITLE
Expand flex behavior for collection quantity controls

### DIFF
--- a/assets/collection-quick-add.css
+++ b/assets/collection-quick-add.css
@@ -55,12 +55,12 @@ input.collection-qty-element:focus {
 }
 
 .collection-qty-group .collection-quantity-input {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
   width: auto;
 }
 
 .collection-qty-group .collection-double-qty-btn {
-  flex: 1 1 auto;
+  flex: 2 2 auto;
   width: auto;
   max-width: none;
 }

--- a/snippets/collection-quick-add.liquid
+++ b/snippets/collection-quick-add.liquid
@@ -42,7 +42,7 @@
                   </button>
                 </collection-quantity-input>
                 {%- if min_qty > 0 and max_qty > 0 or request.design_mode -%}
-                  <button type="button" class="collection-double-qty-btn double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px]" aria-label="{{ double_label }}" data-collection-double-qty data-collection-label-template="{{ label_template }}" data-collection-original-min-qty="{{ min_qty }}">{{ double_label }}</button>
+                  <button type="button" class="collection-double-qty-btn double-qty-btn sf__btn sf__btn-secondary flex-1 max-w-[160px] h-[46px]" aria-label="{{ double_label }}" data-collection-double-qty data-collection-label-template="{{ label_template }}" data-collection-original-min-qty="{{ min_qty }}">{{ double_label }}</button>
                 {%- endif -%}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- allow collection quantity input to flex and size automatically by setting flex to `1 1 auto`
- let double quantity button grow with `flex: 2 2 auto` and no max width so it can expand freely
- ensure double quantity button matches input height with `h-[46px]`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689249e772d0832da780839a87d6caac