### PR TITLE
feat: unify cart error handling

### DIFF
--- a/assets/error-messages.js
+++ b/assets/error-messages.js
@@ -1,0 +1,38 @@
+class CartError {
+  constructor(node) {
+    this.node = node;
+    this.timer = null;
+    if (this.node) {
+      this.msgEl = this.node.querySelector('.sticky-atc-error__msg');
+      if (!this.msgEl) {
+        this.msgEl = document.createElement('span');
+        this.msgEl.className = 'sticky-atc-error__msg';
+        this.node.append(this.msgEl);
+      }
+    }
+  }
+  removeDiacritics(text) {
+    return text && text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+  }
+  show(msg) {
+    if (!this.node) return;
+    clearTimeout(this.timer);
+    if (!msg) msg = window.ConceptSGMStrings.cartError || 'Error';
+    msg = this.removeDiacritics(msg);
+    this.msgEl.textContent = msg;
+    this.node.classList.remove('show');
+    void this.node.offsetWidth;
+    this.node.classList.add('show');
+    this.timer = setTimeout(() => this.hide(), 4000);
+  }
+  hide() {
+    if (!this.node) return;
+    this.node.classList.remove('show');
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.msgEl.textContent = '';
+    }, 300);
+  }
+}
+window.CartError = CartError;
+window.StickyATCError = CartError;

--- a/assets/sticky-atc.js
+++ b/assets/sticky-atc.js
@@ -27,43 +27,8 @@ const ConceptSGMSettings = window.ConceptSGMSettings || {};
 const ConceptSGMStrings = window.ConceptSGMStrings || {};
 const ConceptSGMLibs = window.ConceptSGMLibs || {};
 
-class StickyATCError {
-  constructor(node) {
-    this.node = node;
-    this.timer = null;
-    if (this.node) {
-      this.msgEl = this.node.querySelector('.sticky-atc-error__msg');
-      if (!this.msgEl) {
-        this.msgEl = document.createElement('span');
-        this.msgEl.className = 'sticky-atc-error__msg';
-        this.node.append(this.msgEl);
-      }
-    }
-  }
-  removeDiacritics(text) {
-    return text && text.normalize('NFD').replace(/\p{Diacritic}/gu, '');
-  }
-  show(msg) {
-    if (!this.node) return;
-    clearTimeout(this.timer);
-    if (!msg) msg = window.ConceptSGMStrings.cartError || 'Error';
-    msg = this.removeDiacritics(msg);
-    this.msgEl.textContent = msg;
-    this.node.classList.remove('show');
-    void this.node.offsetWidth;
-    this.node.classList.add('show');
-    this.timer = setTimeout(() => this.hide(), 4000);
-  }
-  hide() {
-    if (!this.node) return;
-    this.node.classList.remove('show');
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
-      this.msgEl.textContent = '';
-    }, 300);
-  }
-}
-window.StickyATCError = StickyATCError;
+// Error handling logic moved to error-messages.js
+window.StickyATCError = window.CartError;
 
 /***/ }),
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -64,9 +64,10 @@ template-{{ template.name | handle }} {{ template.name }}-{{ template.suffix }} 
   <!-- Buton Dublează cantitate -->
   <script src="{{ 'double-qty.js' | asset_url }}" defer="defer"></script>
 
-  <!-- Componente quick add colecție -->
-  <link href="{{ 'collection-quick-add.css' | asset_url }}" rel="stylesheet" type="text/css" />
-  <script src="{{ 'collection-quick-add.js' | asset_url }}" defer="defer"></script>
+    <!-- Componente quick add colecție -->
+    <link href="{{ 'collection-quick-add.css' | asset_url }}" rel="stylesheet" type="text/css" />
+    <script src="{{ 'error-messages.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'collection-quick-add.js' | asset_url }}" defer="defer"></script>
 
 <body
   id="sf-theme"

--- a/snippets/collection-quick-add.liquid
+++ b/snippets/collection-quick-add.liquid
@@ -20,6 +20,7 @@
   endif
 -%}
 {%- if settings.show_cart_button -%}
+  <collection-pcard-error class="sticky-atc-error" aria-live="polite"><span class="sticky-atc-error__msg"></span></collection-pcard-error>
   <div class="sf__pcard-quick-add-col w-full">
     {%- if product.has_only_default_variant -%}
       <collection-product-form class="collection-product-form w-full" data-collection-product-id="{{ product.id }}">


### PR DESCRIPTION
## Summary
- centralize cart error display
- reuse sticky ATC error logic on collection cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925e6e6c48832da2861d78421f877a